### PR TITLE
Support for withPredicate

### DIFF
--- a/app.go
+++ b/app.go
@@ -122,7 +122,7 @@ func router(hh httpHandlers) http.Handler {
 	servicesRouter := mux.NewRouter()
 
 	// Then API specific ones:
-	servicesRouter.HandleFunc("/content", hh.getContentByConcept).Methods("GET")
+	servicesRouter.HandleFunc("/content", hh.selectContentByConceptHandler).Methods("GET")
 	servicesRouter.HandleFunc("/content", hh.methodNotAllowedHandler)
 
 	// Then monitoring

--- a/cypher.go
+++ b/cypher.go
@@ -10,6 +10,7 @@ import (
 // Driver interface
 type driver interface {
 	read(id string, limit int, fromDateEpoch int64, toDateEpoch int64) (contentList, bool, error)
+	readWithPredicate(conceptUUID string, predicateLabel string, limit int, fromDateEpoch int64, toDateEpoch int64) (contentList, bool, error)
 	checkConnectivity() error
 }
 
@@ -51,6 +52,42 @@ func (cd cypherDriver) read(conceptUUID string, limit int, fromDateEpoch int64, 
 			"maxContentItems": limit,
 			"fromDate":        fromDateEpoch,
 			"toDate":          toDateEpoch,
+		},
+		Result: &results,
+	}
+
+	if err := cd.conn.CypherBatch([]*neoism.CypherQuery{query}); err != nil || len(results) == 0 {
+		return contentList{}, false, err
+	}
+
+	log.Debugf("Found %d pieces of content for uuid: %s", len(results), conceptUUID)
+
+	cntList := neoReadStructToContentList(&results, cd.env)
+	return cntList, true, nil
+}
+
+func (cd cypherDriver) readWithPredicate(conceptUUID string, predicateLabel string, limit int, fromDateEpoch int64, toDateEpoch int64) (contentList, bool, error) {
+	results := []neoReadStruct{}
+
+	var whereClause string
+	if fromDateEpoch > 0 && toDateEpoch > 0 {
+		whereClause = " WHERE c.publishedDateEpoch > {fromDate} AND c.publishedDateEpoch < {toDate} "
+	}
+
+	query := &neoism.CypherQuery{
+		Statement: `
+		MATCH (upp:UPPIdentifier{value:{conceptUUID}})-[:IDENTIFIES]->(cc:Concept)
+		MATCH (c:Content)-[rel:{predicate}]->(cc)` +
+			whereClause +
+			`RETURN c.uuid as uuid, labels(c) as types
+		ORDER BY c.publishedDateEpoch DESC
+		LIMIT({maxContentItems})`,
+		Parameters: neoism.Props{
+			"conceptUUID":     conceptUUID,
+			"maxContentItems": limit,
+			"fromDate":        fromDateEpoch,
+			"toDate":          toDateEpoch,
+			"predicate":       predicateLabel,
 		},
 		Result: &results,
 	}

--- a/cypher.go
+++ b/cypher.go
@@ -71,13 +71,14 @@ func (cd cypherDriver) readWithPredicate(conceptUUID string, predicateLabel stri
 
 	var whereClause string
 	if fromDateEpoch > 0 && toDateEpoch > 0 {
-		whereClause = " WHERE c.publishedDateEpoch > {fromDate} AND c.publishedDateEpoch < {toDate} "
+		whereClause = " AND c.publishedDateEpoch > {fromDate} AND c.publishedDateEpoch < {toDate} "
 	}
 
 	query := &neoism.CypherQuery{
 		Statement: `
 		MATCH (upp:UPPIdentifier{value:{conceptUUID}})-[:IDENTIFIES]->(cc:Concept)
-		MATCH (c:Content)-[rel:{predicate}]->(cc)` +
+		MATCH (c:Content)-[rel]->(cc)
+			WHERE type(rel) = {predicate}` +
 			whereClause +
 			`RETURN c.uuid as uuid, labels(c) as types
 		ORDER BY c.publishedDateEpoch DESC

--- a/cypher_test.go
+++ b/cypher_test.go
@@ -270,6 +270,7 @@ func getDatabaseConnection(t *testing.T, assert *assert.Assertions) neoutils.Neo
 	if url == "" {
 		url = "http://localhost:7474/db/data"
 	}
+
 	conf := neoutils.DefaultConnectionConfig()
 	conf.Transactional = false
 	db, err := neoutils.Connect(url, conf)

--- a/cypher_test.go
+++ b/cypher_test.go
@@ -28,7 +28,7 @@ const (
 
 func TestFindMatchingContentForV2Annotation(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	organisationRW := writeOrganisations(assert, db)
@@ -49,7 +49,7 @@ func TestFindMatchingContentForV2Annotation(t *testing.T) {
 
 func TestFindMatchingContentForV1Annotation(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	organisationRW := writeOrganisations(assert, db)
@@ -72,7 +72,7 @@ func TestFindMatchingContentForV1Annotation(t *testing.T) {
 
 func TestFindMatchingContentForV2AnnotationWithLimit(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	contentRW2 := writeContent(assert, db, content2UUID)
@@ -97,7 +97,7 @@ func TestFindMatchingContentForV2AnnotationWithLimit(t *testing.T) {
 
 func TestRetrieveNoContentForV1AnnotationForExclusiveDatePeriod(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	organisationRW := writeOrganisations(assert, db)
@@ -121,7 +121,7 @@ func TestRetrieveNoContentForV1AnnotationForExclusiveDatePeriod(t *testing.T) {
 
 func TestRetrieveNoContentWhenThereAreNoContentForThatConcept(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	organisationRW := writeOrganisations(assert, db)
@@ -139,7 +139,7 @@ func TestRetrieveNoContentWhenThereAreNoContentForThatConcept(t *testing.T) {
 
 func TestRetrieveNoContentWhenThereAreNoConceptsPresent(t *testing.T) {
 	assert := assert.New(t)
-	db := getDatabaseConnection(assert)
+	db := getDatabaseConnection(t, assert)
 
 	contentRW := writeContent(assert, db, contentUUID)
 	annotationsRWV1 := writeV1Annotations(assert, db)
@@ -261,7 +261,11 @@ func assertListContainsAll(assert *assert.Assertions, list interface{}, items ..
 	}
 }
 
-func getDatabaseConnection(assert *assert.Assertions) neoutils.NeoConnection {
+func getDatabaseConnection(t *testing.T, assert *assert.Assertions) neoutils.NeoConnection {
+	if testing.Short() {
+		t.Skip("Short flag set - skipping Neo4j integration test.")
+	}
+
 	url := os.Getenv("NEO4J_TEST_URL")
 	if url == "" {
 		url = "http://localhost:7474/db/data"

--- a/handlers.go
+++ b/handlers.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Financial-Times/go-fthealth/v1a"
-	log "github.com/Sirupsen/logrus"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Financial-Times/go-fthealth/v1a"
+	log "github.com/Sirupsen/logrus"
 )
 
 type httpHandlers struct {
@@ -63,95 +63,113 @@ func (hh *httpHandlers) methodNotAllowedHandler(w http.ResponseWriter, r *http.R
 }
 
 func (hh *httpHandlers) getContentByConcept(w http.ResponseWriter, r *http.Request) {
-
-	m, _ := url.ParseQuery(r.URL.RawQuery)
-
-	_, isAnnotatedByPresent := m["isAnnotatedBy"]
-
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-
-	if !isAnnotatedByPresent {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(
-			`{"message": "Missing or empty query parameter isAnnotatedBy. Expecting valid absolute concept URI."}`))
+	conceptURI, found, err := getSingleValueQueryParameter(r, "isAnnotatedBy")
+	if !found {
+		writeHTTPMessage(w, http.StatusBadRequest, `Missing query parameter "isAnnotatedBy". Expecting exactly one valid absolute Concept URI.`)
 		return
 	}
 
-	if len(m["isAnnotatedBy"]) > 1 {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(
-			`{"message": "Only one concept uri should be provided"}`))
+	if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value found for query parameter "isAnnotatedBy". Expecting exactly one valid absolute Concept URI.`)
 		return
 	}
 
-	conceptUri := m["isAnnotatedBy"][0]
-
-	if conceptUri == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(
-			`{"message": "Missing concept URI."}`))
+	if strings.TrimSpace(conceptURI) == "" {
+		writeHTTPMessage(w, http.StatusBadRequest, `No value specified for Concept URI.`)
 		return
 	}
 
-	conceptUuid := strings.TrimPrefix(conceptUri, thingURIPrefix)
+	limitText, found, err := getSingleValueQueryParameter(r, "limit")
+	if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `Please provide one value for "limit".`)
+		return
+	}
 
-	limitParam := m.Get("limit")
 	var limit int
-	var err error
-
-	if limitParam == "" {
+	if !found {
 		log.Infof("No limit provided. Using default: %v", defaultLimit)
 		limit = defaultLimit
 	} else {
-		limit, err = strconv.Atoi(limitParam)
+		limit, err = strconv.Atoi(limitText)
+		if err != nil {
+			writeHTTPMessage(w, http.StatusBadRequest, fmt.Sprintf("Error limit is not a number: %s.", limitText))
+			return
+		}
 	}
 
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		msg := fmt.Sprintf(`{"message":"Error limit is not a number: %s."}`, limitParam)
-		w.Write([]byte(msg))
-		return
-	}
+	conceptUUID := strings.TrimPrefix(conceptURI, thingURIPrefix)
 
-	fromDateParam := m.Get("fromDate")
-	toDateParam := m.Get("toDate")
-	var fromDateEpoch, toDateEpoch int64
-
-	if fromDateParam == "" {
-		log.Infof("No fromDate supplied.")
-	} else {
-		fromDateEpoch = convertStringToDateTimeEpoch(fromDateParam)
-	}
-
-	if toDateParam == "" {
-		log.Infof("No toDate supplied")
-	} else {
-		toDateEpoch = convertStringToDateTimeEpoch(toDateParam)
-	}
-
-	contentList, found, err := hh.contentDriver.read(conceptUuid, limit, fromDateEpoch, toDateEpoch)
-
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		msg := fmt.Sprintf(`{"message":"Error getting content for concept with uuid %s, err=%s"}`, conceptUuid, err.Error())
-		w.Write([]byte(msg))
-		return
-	}
+	toDateEpoch, found, err := getDateParam(r, "toDate")
 	if !found {
-		w.WriteHeader(http.StatusNotFound)
-		msg := fmt.Sprintf(`{"message":"No content found for concept with uuid %s."}`, conceptUuid)
-		w.Write([]byte(msg))
+		log.Infof("No toDate supplied.")
+	} else if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value for "toDate" supplied. Please provide exactly one value.`)
+		return
+	}
+
+	fromDateEpoch, found, err := getDateParam(r, "fromDate")
+	if !found {
+		log.Infof("No fromDate supplied.")
+	} else if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value for "fromDate" supplied. Please provide exactly one value.`)
+		return
+	}
+
+	contentByConcept, found, err := hh.contentDriver.read(conceptUUID, limit, fromDateEpoch, toDateEpoch)
+	if err != nil {
+		writeHTTPMessage(w, http.StatusServiceUnavailable, fmt.Sprintf("Error getting content for concept with uuid %s, err=%s", conceptUUID, err.Error()))
+		return
+	}
+
+	if !found {
+		writeHTTPMessage(w, http.StatusNotFound, fmt.Sprintf("No content found for concept with uuid %s.", conceptUUID))
+		return
+	}
+
+	responseJSON, err := json.Marshal(contentByConcept)
+	if err != nil {
+		writeHTTPMessage(w, http.StatusInternalServerError, fmt.Sprintf(`Error parsing content for concept with uuid %s, err=%s`, conceptUUID, err.Error()))
 		return
 	}
 
 	w.Header().Set("Cache-Control", hh.cacheControlHeader)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	w.Write(responseJSON)
+}
 
-	if err = json.NewEncoder(w).Encode(contentList); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		msg := fmt.Sprintf(`{"message":"Error parsing content for concept with uuid %s, err=%s"}`, conceptUuid, err.Error())
-		w.Write([]byte(msg))
+func getDateParam(req *http.Request, name string) (int64, bool, error) {
+	dateParam, found, err := getSingleValueQueryParameter(req, name)
+	if err != nil || !found {
+		return 0, found, err
 	}
+
+	return convertStringToDateTimeEpoch(dateParam), found, nil
+}
+
+func getSingleValueQueryParameter(req *http.Request, param string) (string, bool, error) {
+	query := req.URL.Query()
+	values, found := query[param]
+	if len(values) > 1 {
+		return "", found, fmt.Errorf("specified multiple %v query parameters in the URL", param)
+	}
+
+	if len(values) < 1 {
+		return "", found, nil
+	}
+
+	return values[0], found, nil
+}
+
+func writeHTTPMessage(w http.ResponseWriter, status int, message string) {
+	resp := make(map[string]string)
+	resp["message"] = message
+
+	w.WriteHeader(status)
+	w.Header().Add("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	enc.Encode(&resp)
 }
 
 func convertStringToDateTimeEpoch(dateString string) int64 {

--- a/handlers.go
+++ b/handlers.go
@@ -62,6 +62,20 @@ func (hh *httpHandlers) methodNotAllowedHandler(w http.ResponseWriter, r *http.R
 	return
 }
 
+func (hh *httpHandlers) selectContentByConceptHandler(w http.ResponseWriter, r *http.Request) {
+	predicate, found, err := getSingleValueQueryParameter(r, "withPredicate")
+	if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value found for query parameter "withPredicate". Expecting exactly one valid absolute predicate URI.`)
+		return
+	}
+
+	if found {
+		hh.getContentByConceptWithPredicate(w, r, predicate)
+	} else {
+		hh.getContentByConcept(w, r)
+	}
+}
+
 func (hh *httpHandlers) getContentByConcept(w http.ResponseWriter, r *http.Request) {
 	conceptURI, found, err := getSingleValueQueryParameter(r, "isAnnotatedBy")
 	if !found {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -78,6 +78,16 @@ func (dS dummyService) read(conceptUUID string, limit int, fromDateEpoch int64, 
 	return nil, false, nil
 }
 
+func (dS dummyService) readWithPredicate(conceptUUID string, label string, limit int, fromDateEpoch int64, toDateEpoch int64) (contentList, bool, error) {
+	if dS.failRead {
+		return nil, false, errors.New("TEST failing to READ")
+	}
+	if conceptUUID == dS.contentUUID {
+		return contentList{}, true, nil
+	}
+	return nil, false, nil
+}
+
 func (dS dummyService) checkConnectivity() error {
 	return nil
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -26,8 +26,20 @@ func TestGetHandler(t *testing.T) {
 	assert := assert.New(t)
 	tests := []test{
 		{"Success", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithLimit", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=2`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=2006-01-02`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=2006-01-02`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessDespiteInvalidFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=0`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessDespiteInvalidToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=0`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
 		{"NotFound", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s", "99999"), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusNotFound, "", message("No content found for concept with uuid 99999.")},
 		{"ReadError", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", message("Error getting content for concept with uuid 12345, err=TEST failing to READ")},
+		{"LimitShouldBeNumber", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=huh`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message("Error limit is not a number: huh.")},
+		{"ExactlyOneLimit", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=10&limit=50`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`Please provide one value for \"limit\".`)},
+		{"MissingAnnotatedBy", newRequest("GET", "/content", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`Missing query parameter \"isAnnotatedBy\". Expecting exactly one valid absolute Concept URI.`)},
+		{"BlankAnnotatedBy", newRequest("GET", "/content?isAnnotatedBy=", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`No value specified for Concept URI.`)},
+		{"MoreThanOneAnnotatedBy", newRequest("GET", "/content?isAnnotatedBy=blah&isAnnotatedBy=blah-again", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value found for query parameter \"isAnnotatedBy\". Expecting exactly one valid absolute Concept URI.`)},
+		{"MoreThanOneToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=0&toDate=1`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value for \"toDate\" supplied. Please provide exactly one value.`)},
+		{"MoreThanOneFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=0&fromDate=1`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value for \"fromDate\" supplied. Please provide exactly one value.`)},
 	}
 
 	for _, test := range tests {

--- a/predicate_handler.go
+++ b/predicate_handler.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/fleet/log"
+)
+
+var predicateToLabelMap = map[string]string{
+	"http://www.ft.com/ontology/annotation/hasAuthor": "HAS_AUTHOR",
+}
+
+func (hh *httpHandlers) getContentByConceptWithPredicate(w http.ResponseWriter, r *http.Request, predicate string) {
+	label, ok := predicateToLabelMap[predicate]
+	if !ok {
+		writeHTTPMessage(w, http.StatusNotImplemented, `Provided "withPredicate" value is currently unsupported.`)
+		return
+	}
+
+	conceptURI, found, err := getSingleValueQueryParameter(r, "isAnnotatedBy")
+	if !found {
+		writeHTTPMessage(w, http.StatusBadRequest, `Missing query parameter "isAnnotatedBy". Expecting exactly one valid absolute Concept URI.`)
+		return
+	}
+
+	if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value found for query parameter "isAnnotatedBy". Expecting exactly one valid absolute Concept URI.`)
+		return
+	}
+
+	if strings.TrimSpace(conceptURI) == "" {
+		writeHTTPMessage(w, http.StatusBadRequest, `No value specified for Concept URI.`)
+		return
+	}
+
+	limitText, found, err := getSingleValueQueryParameter(r, "limit")
+	if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `Please provide one value for "limit".`)
+		return
+	}
+
+	var limit int
+	if !found {
+		log.Infof("No limit provided. Using default: %v", defaultLimit)
+		limit = defaultLimit
+	} else {
+		limit, err = strconv.Atoi(limitText)
+		if err != nil {
+			writeHTTPMessage(w, http.StatusBadRequest, fmt.Sprintf("Error limit is not a number: %s.", limitText))
+			return
+		}
+	}
+
+	conceptUUID := strings.TrimPrefix(conceptURI, thingURIPrefix)
+
+	toDateEpoch, found, err := getDateParam(r, "toDate")
+	if !found {
+		log.Infof("No toDate supplied.")
+	} else if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value for "toDate" supplied. Please provide exactly one value.`)
+		return
+	}
+
+	fromDateEpoch, found, err := getDateParam(r, "fromDate")
+	if !found {
+		log.Infof("No fromDate supplied.")
+	} else if err != nil {
+		writeHTTPMessage(w, http.StatusBadRequest, `More than one value for "fromDate" supplied. Please provide exactly one value.`)
+		return
+	}
+
+	contentByConcept, found, err := hh.contentDriver.readWithPredicate(conceptUUID, label, limit, fromDateEpoch, toDateEpoch)
+	if err != nil {
+		writeHTTPMessage(w, http.StatusServiceUnavailable, fmt.Sprintf("Error getting content for concept with uuid %s, err=%s", conceptUUID, err.Error()))
+		return
+	}
+
+	if !found {
+		writeHTTPMessage(w, http.StatusNotFound, fmt.Sprintf("No content found for concept with uuid %s.", conceptUUID))
+		return
+	}
+
+	responseJSON, err := json.Marshal(contentByConcept)
+	if err != nil {
+		writeHTTPMessage(w, http.StatusInternalServerError, fmt.Sprintf(`Error parsing content for concept with uuid %s, err=%s`, conceptUUID, err.Error()))
+		return
+	}
+
+	w.Header().Set("Cache-Control", hh.cacheControlHeader)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(responseJSON)
+}

--- a/predicate_handler_test.go
+++ b/predicate_handler_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWithPredicateHandler(t *testing.T) {
+	assert := assert.New(t)
+	tests := []test{
+		{"Success", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithLimit", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=2&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=2006-01-02&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessWithFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=2006-01-02&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessDespiteInvalidFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=0&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"SuccessDespiteInvalidToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=0&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
+		{"NotFound", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", "99999"), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusNotFound, "", message("No content found for concept with uuid 99999.")},
+		{"ReadError", newRequest("GET", fmt.Sprintf("/content?isAnnotatedBy=http://api.ft.com/things/%s&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", message("Error getting content for concept with uuid 12345, err=TEST failing to READ")},
+		{"LimitShouldBeNumber", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=huh&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message("Error limit is not a number: huh.")},
+		{"ExactlyOneLimit", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=http://api.ft.com/things/%s&limit=10&limit=50&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`Please provide one value for \"limit\".`)},
+		{"MissingAnnotatedBy", newRequest("GET", "/content?withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`Missing query parameter \"isAnnotatedBy\". Expecting exactly one valid absolute Concept URI.`)},
+		{"BlankAnnotatedBy", newRequest("GET", "/content?isAnnotatedBy=&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`No value specified for Concept URI.`)},
+		{"MoreThanOneAnnotatedBy", newRequest("GET", "/content?isAnnotatedBy=blah&isAnnotatedBy=blah-again&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor", "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value found for query parameter \"isAnnotatedBy\". Expecting exactly one valid absolute Concept URI.`)},
+		{"MoreThanOneToDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&toDate=0&toDate=1&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value for \"toDate\" supplied. Please provide exactly one value.`)},
+		{"MoreThanOneFromDate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&fromDate=0&fromDate=1&withPredicate=http://www.ft.com/ontology/annotation/hasAuthor`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value for \"fromDate\" supplied. Please provide exactly one value.`)},
+		{"UnsupportedPredicate", newRequest("GET", fmt.Sprintf(`/content?isAnnotatedBy=%s&withPredicate=http://www.ft.com/ontology/annotation/hasSomethingElse`, knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusNotImplemented, "", message(`Provided \"withPredicate\" value is currently unsupported.`)},
+		{"TooManyPredicates", newRequest("GET", `/content?withPredicate=http://www.ft.com/ontology/annotation/hasSomething&withPredicate=http://www.ft.com/ontology/annotation/hasSomethingElse`, "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusBadRequest, "", message(`More than one value found for query parameter \"withPredicate\". Expecting exactly one valid absolute predicate URI.`)},
+	}
+
+	for _, test := range tests {
+		rec := httptest.NewRecorder()
+		router(httpHandlers{test.dummyService, "max-age=360, public"}).ServeHTTP(rec, test.req)
+		assert.True(test.statusCode == rec.Code, fmt.Sprintf("%s: Wrong response code, was %d, should be %d", test.name, rec.Code, test.statusCode))
+		assert.JSONEq(test.body, rec.Body.String(), fmt.Sprintf("%s: Wrong body", test.name))
+	}
+}


### PR DESCRIPTION
Content by concept searches can now be optionally filtered by a predicate. 

Currently only `HAS_AUTHOR -> http://www.ft.com/ontology/annotation/hasAuthor` is mapped and supported - all other predicates will 501 Not Implemented.

I've tried to keep the http endpoint code as separate as possible (i.e. not refactoring out the checking of the properties within the request), so that they can work independently of each other - but happy to move that to the parent `selectContentByConceptHandler` func if that's an issue.