### PR TITLE
Remove the dependency on `neo-model-utils-go`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@ __A public API which returns an ordered list of the most recently annotated cont
 * `go install`
 * `$GOPATH/bin/public-content-by-concept-api --neo-url={neo4jUrl} --port={port} --log-level={DEBUG|INFO|WARN|ERROR}--cache-duration{e.g. 22h10m3s} --requestLoggingEnabled=false`
 
-  Optional arguments are:
-  * --neo-url defaults to bolt://neo4j:7687, which is the default url to connect to single Neo4j instance using bolt protocol.
-  * --port defaults to 8080.
-  * --cache-duration defaults to 1 hour
-  * --logLevel set level of app logging, request critical logs are info level with more helpful logs found at debug
-  * --requestLoggingEnabled when true will toggle logging of both admin endpoints(health/gtg) as well as http endpoints_
+```shell
+Options:
+  --app-system-code       System Code of the application (env $APP_SYSTEM_CODE) (default "public-content-by-concept-api")
+  --app-name              Application name (env $APP_NAME) (default "Public Content by Concept API")
+  --neo-url               neo4j endpoint URL (env $NEO_URL) (default "bolt://localhost:7687")
+  --port                  Port to listen on (env $APP_PORT) (default "8080")
+  --cache-duration        Duration Get requests should be cached for. e.g. 2h45m would set the max-age value to '7440' seconds (env $CACHE_DURATION) (default "30s")
+  --record-http-metrics   enable recording of http handler metrics (env $RECORD_HTTP_METRICS)
+  --logLevel              Level of logging in the service (env $LOG_LEVEL) (default "INFO")
+  --dbDriverLogLevel      Level of logging in the service (env $DB_DRIVER_LOG_LEVEL) (default "WARNING")
+  --api-yml               Location of the API Swagger YML file. (env $API_YML) (default "./api.yml")
+  --publicAPIURL          API Gateway URL used when building the thing ID url in the response, in the format scheme://host (env $PUBLIC_API_URL) (default "http://api.ft.com")
+  --ftURL                 FT's URL used when building the ID url in the response, in the format scheme://host (env $FT_URL) (default "http://www.ft.com")
+```
 
 ## Testing
 * Unit tests only: `go test -race ./...`

--- a/content/service_test.go
+++ b/content/service_test.go
@@ -44,6 +44,8 @@ const (
 	topic2UUID              = "64ba2208-0c0d-43e2-a883-beecb55c0d33"
 	topic3UUID              = "2e7429bd-7a84-41cb-a619-2c702893e359"
 	brand1UUID              = "5c7592a8-1f0c-11e4-b0cb-b2227cce2b54"
+
+	apigURL = "http://api.ft.com"
 )
 
 const defaultLimit = 10
@@ -77,7 +79,8 @@ func TestFindMatchingContentForV2Annotation(t *testing.T) {
 
 	defer cleanDB(t, MSJConceptUUID, contentUUID, FakebookConceptUUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	contentList, err := contentByConceptDriver.GetContentForConcept(MSJConceptUUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", MSJConceptUUID)
 	assert.Equal(1, len(contentList), "Didn't get the same list of content")
@@ -93,7 +96,8 @@ func TestFindMatchingContentForV1Annotation(t *testing.T) {
 
 	defer cleanDB(t, MSJConceptUUID, contentUUID, FakebookConceptUUID, MetalMickeyConceptUUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	contentList, err := contentByConceptDriver.GetContentForConcept(MetalMickeyConceptUUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", MetalMickeyConceptUUID)
 	assert.Equal(1, len(contentList), "Didn't get the same list of content")
@@ -110,7 +114,8 @@ func TestFindMatchingContentForV2AnnotationWithLimit(t *testing.T) {
 
 	defer cleanDB(t, MSJConceptUUID, contentUUID, FakebookConceptUUID, content2UUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	contentList, err := contentByConceptDriver.GetContentForConcept(MSJConceptUUID, RequestParams{0, 1, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", MSJConceptUUID)
 	assert.Equal(1, len(contentList), "Didn't get the same list of content")
@@ -126,7 +131,8 @@ func TestRetrieveNoContentForV1AnnotationForExclusiveDatePeriod(t *testing.T) {
 
 	defer cleanDB(t, MSJConceptUUID, contentUUID, FakebookConceptUUID, MetalMickeyConceptUUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	fromDate, _ := time.Parse("2006-01-02", "2014-03-08")
 	toDate, _ := time.Parse("2006-01-02", "2014-03-09")
 	contentList, err := contentByConceptDriver.GetContentForConcept(MetalMickeyConceptUUID, RequestParams{0, defaultLimit, fromDate.Unix(), toDate.Unix()})
@@ -141,7 +147,8 @@ func TestRetrieveNoContentWhenThereAreNoContentForThatConcept(t *testing.T) {
 
 	defer cleanDB(t, MSJConceptUUID, contentUUID, FakebookConceptUUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	content, err := contentByConceptDriver.GetContentForConcept(MSJConceptUUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.Equal(ErrContentNotFound, err, "Found matching content for concept %s", MetalMickeyConceptUUID)
 	assert.Equal(0, len(content), "Should not get any content items")
@@ -156,7 +163,8 @@ func TestRetrieveNoContentWhenThereAreNoConceptsPresent(t *testing.T) {
 
 	defer cleanDB(t, content2UUID, MSJConceptUUID, contentUUID, MetalMickeyConceptUUID, FakebookConceptUUID)
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	contentList, err := contentByConceptDriver.GetContentForConcept(MSJConceptUUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.Equal(ErrContentNotFound, err, "Found matching content for concept %s", MetalMickeyConceptUUID)
 	assert.Equal(0, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
@@ -177,7 +185,8 @@ func TestBrandsDontReturnParentContent(t *testing.T) {
 	writeConcept(assert, driver, fmt.Sprintf("./fixtures/Brand-OnyxPike-%v.json", OnyxPikeBrandUUID))
 	writeConcept(assert, driver, fmt.Sprintf("./fixtures/Brand-OnyxPikeParent-%v.json", OnyxPikeParentBrandUUID))
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 	contentList, err := contentByConceptDriver.GetContentForConcept(OnyxPikeBrandUUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", OnyxPikeBrandUUID)
 	assert.Equal(2, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
@@ -200,7 +209,8 @@ func TestContentIsReturnedFromAllLeafNodesOfConcordance(t *testing.T) {
 
 	writeConcept(assert, driver, "./fixtures/Person-JohnSmith-f25b0f71-4cf9-4e3a-8510-14e86d922bfe.json")
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 
 	idsToCheck := []string{JohnSmithFSUUID, JohnSmithSmartlogicUUID, JohnSmithTMEUUID, JohnSmithOtherTMEUUID}
 
@@ -228,7 +238,8 @@ func TestContentIsReturnedFromAllLeafNodesOfConcordanceWithDateRestrictions(t *t
 
 	writeConcept(assert, driver, "./fixtures/Person-JohnSmith-f25b0f71-4cf9-4e3a-8510-14e86d922bfe.json")
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 
 	idsToCheck := []string{JohnSmithFSUUID, JohnSmithSmartlogicUUID, JohnSmithTMEUUID, JohnSmithOtherTMEUUID}
 
@@ -257,7 +268,8 @@ func TestContentIsReturnedFromAllLeafNodesOfConcordanceWithPagination(t *testing
 
 	writeConcept(assert, driver, "./fixtures/Person-JohnSmith-f25b0f71-4cf9-4e3a-8510-14e86d922bfe.json")
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 
 	idsToCheck := []string{JohnSmithFSUUID, JohnSmithSmartlogicUUID, JohnSmithTMEUUID, JohnSmithOtherTMEUUID}
 
@@ -301,7 +313,8 @@ func TestContentIsReturnedImplicitlyForHasBroaderOrHasParentOrIsPartOfRelationsh
 	writeConcept(assert, driver, "./fixtures/Topic-18e24d65-c8e6-4e23-ab19-206e0d463205.json")
 	writeConcept(assert, driver, "./fixtures/Topic-64ba2208-0c0d-43e2-a883-beecb55c0d33.json")
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 
 	contentList1, err := contentByConceptDriver.GetContentForConcept(topic1UUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", topic1UUID)
@@ -330,7 +343,8 @@ func TestContentIsReturnedImplicitlyForImpliedByRelationship(t *testing.T) {
 	writeConcept(assert, driver, "./fixtures/Brand-5c7592a8-1f0c-11e4-b0cb-b2227cce2b54.json")
 	writeConcept(assert, driver, "./fixtures/Topic-2e7429bd-7a84-41cb-a619-2c702893e359.json")
 
-	contentByConceptDriver := NewContentByConceptService(driver)
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
 
 	contentList1, err := contentByConceptDriver.GetContentForConcept(brand1UUID, RequestParams{0, defaultLimit, 0, 0})
 	assert.NoError(err, "Unexpected error for concept %s", brand1UUID)
@@ -347,8 +361,9 @@ func TestContentIsReturnedImplicitlyForImpliedByRelationship(t *testing.T) {
 
 func TestConceptService_Check(t *testing.T) {
 	assert := assert.New(t)
-	contentByConceptDriver := NewContentByConceptService(driver)
-	_, err := contentByConceptDriver.CheckConnection()
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
+	_, err = contentByConceptDriver.CheckConnection()
 	assert.NoError(err, "Test should always pass when connected to db")
 }
 

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - neo4j
   neo4j:
-    image: neo4j:4.3.6-enterprise
+    image: neo4j:4.4-enterprise
     environment:
           NEO4J_AUTH: none
           NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/Financial-Times/go-fthealth v0.0.0-20180807113633-3d8eb430d5b5
 	github.com/Financial-Times/go-logger/v2 v2.0.1
 	github.com/Financial-Times/http-handlers-go/v2 v2.3.0
-	github.com/Financial-Times/neo-model-utils-go v1.0.0
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v1.0.0
 	github.com/gorilla/mux v1.6.2
@@ -24,6 +23,7 @@ require (
 require (
 	github.com/Financial-Times/cm-graph-ontology v0.0.1 // indirect
 	github.com/Financial-Times/http-handlers-go v0.0.0-20180517120644-2c20324ab887 // indirect
+	github.com/Financial-Times/neo-model-utils-go v1.0.0 // indirect
 	github.com/Financial-Times/up-rw-app-api-go v0.0.0-20170710125828-d9d93a1f6895 // indirect
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/Financial-Times/go-logger/v2"
-	"github.com/Financial-Times/neo-model-utils-go/mapper"
 	"github.com/Financial-Times/public-content-by-concept-api/v2/content"
 	"github.com/stretchr/testify/assert"
 )
@@ -275,8 +274,8 @@ func (dS dummyService) GetContentForConcept(conceptUUID string, params content.R
 	cntList := make([]content.Content, 0)
 	for _, contentID := range dS.contentIDList {
 		var con = content.Content{}
-		con.APIURL = mapper.APIURL(contentID, []string{"Content", "Thing"}, "")
-		con.ID = content.ThingsPrefix + contentID
+		con.APIURL = apiURL(contentID)
+		con.ID = idURL(contentID)
 		cntList = append(cntList, con)
 	}
 
@@ -294,8 +293,8 @@ func (dS dummyService) GetContentForConceptImplicitly(conceptUUID string) ([]con
 	cntList := make([]content.Content, 0)
 	for _, contentID := range dS.contentIDList {
 		var con = content.Content{}
-		con.APIURL = mapper.APIURL(contentID, []string{"Content", "Thing"}, "")
-		con.ID = content.ThingsPrefix + contentID
+		con.APIURL = apiURL(contentID)
+		con.ID = idURL(contentID)
 		cntList = append(cntList, con)
 	}
 
@@ -304,4 +303,12 @@ func (dS dummyService) GetContentForConceptImplicitly(conceptUUID string) ([]con
 
 func (dS dummyService) CheckConnection() (string, error) {
 	return "", nil
+}
+
+func apiURL(uuid string) string {
+	return "http://api.ft.com/content/" + uuid
+}
+
+func idURL(uuid string) string {
+	return "http://www.ft.com/content/" + uuid
 }

--- a/helm/public-content-by-concept-api/templates/deployment.yaml
+++ b/helm/public-content-by-concept-api/templates/deployment.yaml
@@ -51,6 +51,11 @@ spec:
           value: "{{ .Values.env.logLevel }}"
         - name: DB_DRIVER_LOG_LEVEL
           value: "{{ .Values.env.dbDriverLogLevel }}"
+        - name: PUBLIC_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: api.host.with.protocol.insecure
         ports:
         - containerPort: {{ .Values.env.app.port }}
         livenessProbe:

--- a/main.go
+++ b/main.go
@@ -72,6 +72,12 @@ func main() {
 		Desc:   "Location of the API Swagger YML file.",
 		EnvVar: "API_YML",
 	})
+	apiURL := app.String(cli.StringOpt{
+		Name:   "publicAPIURL",
+		Value:  "http://api.ft.com",
+		Desc:   "API Gateway URL used when building the thing ID url in the response, in the format scheme://host",
+		EnvVar: "PUBLIC_API_URL",
+	})
 
 	log := logger.NewUPPLogger(*appName, *logLevel)
 	dbLog := logger.NewUPPLogger(fmt.Sprintf("%s %s", *appName, "cmneo4j-driver"), *dbDriverLogLevel)
@@ -94,7 +100,7 @@ func main() {
 			NeoURL:         *neoURL,
 		}
 
-		stopSrv, err := StartServer(config, log, dbLog)
+		stopSrv, err := StartServer(config, log, dbLog, *apiURL)
 		if err != nil {
 			log.WithError(err).Fatal("Could not start the server")
 		}


### PR DESCRIPTION
# Description

The package will be archived soon and its successor `cm-graph-ontology` does not have support for content nodes yet.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4239)

## Anything, in particular, you'd like to highlight to reviewers

_Previously content with types different than `Content` or `ContentPackage` had `apiUrl` in the from `http://api.ft.com/things` because `neo-model-utils-go` didn't know about those content types. Now every `apiUrl` is in the form `http://api.ft.com/content`. I believe that this is the correct behaviour_

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [x] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
