### PR TITLE
add test for FTA and fix the sourceURL according the new graph ontolo…

### DIFF
--- a/content/fixtures/Annotations-22e528d3-4ceb-452f-bf88-0ff6b99eab22-manual.json
+++ b/content/fixtures/Annotations-22e528d3-4ceb-452f-bf88-0ff6b99eab22-manual.json
@@ -1,0 +1,17 @@
+[
+    {
+        "predicate": "http://www.ft.com/ontology/annotation/isSponsoredBy",
+        "id": "http://api.ft.com/things/11a8748c-24f9-4034-809b-eb5fcabf9611",
+        "apiUrl": "http://api-t.ft.com/concepts/11a8748c-24f9-4034-809b-eb5fcabf9611",
+        "types": [
+            "http://www.ft.com/ontology/core/Thing",
+            "http://www.ft.com/ontology/concept/Concept",
+            "http://www.ft.com/ontology/classification/Classification",
+            "http://www.ft.com/ontology/FTAGenre"
+        ],
+        "prefLabel": "FTA Genre Test Label",
+        "publication": [
+            "19d50190-8656-4e91-8d34-82e646ada9c9"
+        ]
+    }
+]

--- a/content/fixtures/Content-22e528d3-4ceb-452f-bf88-0ff6b99eab22.json
+++ b/content/fixtures/Content-22e528d3-4ceb-452f-bf88-0ff6b99eab22.json
@@ -1,0 +1,13 @@
+{
+  "uuid": "22e528d3-4ceb-452f-bf88-0ff6b99eab22",
+  "title": "FTA content to be annotated with isSponsoredBy",
+  "identifiers": [
+    {
+      "authority": "19d50190-8656-4e91-8d34-82e646ada9c9",
+      "identifierValue": "22e528d3-4ceb-452f-bf88-0ff6b99eab22"
+    }
+  ],
+  "publication": ["19d50190-8656-4e91-8d34-82e646ada9c9"],
+  "publishedDate": "2023-03-07T19:18:01.000Z",
+  "body": "<body>Yet another testing document</body>"
+}

--- a/content/fixtures/FTAGenre-11a8748c-24f9-4034-809b-eb5fcabf9611.json
+++ b/content/fixtures/FTAGenre-11a8748c-24f9-4034-809b-eb5fcabf9611.json
@@ -1,0 +1,17 @@
+{
+    "prefLabel": "FTA Genre Test Label",
+    "prefUUID": "11a8748c-24f9-4034-809b-eb5fcabf9611",
+    "publicationDate": "01/01/1999",
+    "sourceRepresentations": [
+        {
+            "authority": "19d50190-8656-4e91-8d34-82e646ada9c9",
+            "authorityValue": "72d7e1ff-afa5-427c-a5f1-205e08c83c97",
+            "lastModifiedEpoch": 1706788394,
+            "prefLabel": "FTA Genre Test Label",
+            "type": "FTAGenre",
+            "uuid": "11a8748c-24f9-4034-809b-eb5fcabf9611"
+        }
+    ],
+    "type": "FTAGenre",
+    "publication": ["19d50190-8656-4e91-8d34-82e646ada9c9"]
+}

--- a/content/fixtures/Sv-provision-a7a8748c-24f9-4034-809b-eb5fcabf96f4.json
+++ b/content/fixtures/Sv-provision-a7a8748c-24f9-4034-809b-eb5fcabf96f4.json
@@ -16,7 +16,9 @@
             "uuid": "a7a8748c-24f9-4034-809b-eb5fcabf96f4"
         }
     ],
-    "sourceURL": "https://www.bmgk.bg/%d0%b1%d1%8e%d0%bb%d0%b5%d1%82%d0%b8%d0%bd-%d0%b0%d1%80%d1%85%d0%b8%d0%b2/#",
+    "sourceURL": [
+        "https://www.bmgk.bg/%d0%b1%d1%8e%d0%bb%d0%b5%d1%82%d0%b8%d0%bd-%d0%b0%d1%80%d1%85%d0%b8%d0%b2/#"
+    ],
     "subtype": "Guidance",
     "type": "SVProvision",
     "publication": ["8e6c705e-1132-42a2-8db0-c295e29e8658"]

--- a/content/service_test.go
+++ b/content/service_test.go
@@ -34,6 +34,7 @@ const (
 	content8UUID            = "4e6a0098-94a9-45c1-835c-7572e1fcc567"
 	content9UUID            = "3fc9fe3e-af8c-4f7f-961a-e5065392bb32"
 	content10UUID           = "93e528d3-4ceb-452f-bf88-0ff6b99eab8b"
+	content11UUID           = "22e528d3-4ceb-452f-bf88-0ff6b99eab22"
 	MSJConceptUUID          = "5d1510f8-2779-4b74-adab-0a5eb138fca6"
 	FakebookConceptUUID     = "eac853f5-3859-4c08-8540-55e043719400"
 	MetalMickeyConceptUUID  = "0483bef8-5797-40b8-9b25-b12e492f63c6"
@@ -51,8 +52,9 @@ const (
 	provision1UUID          = "a7a8748c-24f9-4034-809b-eb5fcabf96f4"
 	svPublicationID         = "8e6c705e-1132-42a2-8db0-c295e29e8658"
 	ftPinkPublicationtionID = "88fdde6c-2aa4-4f78-af02-9f680097cfd6"
-
-	apigURL = "http://api.ft.com"
+	FTAGenreUUID            = "11a8748c-24f9-4034-809b-eb5fcabf9611"
+	FTAPublicationUUUID     = "19d50190-8656-4e91-8d34-82e646ada9c9"
+	apigURL                 = "http://api.ft.com"
 )
 
 const defaultLimit = 10
@@ -408,6 +410,25 @@ func TestSVRelationship(t *testing.T) {
 	assert.NoError(err, "Unexpected error for concept %s", provision1UUID)
 	assert.Equal(1, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
 	assertListContainsAll(assert, contentList, getExpectedContent(content10UUID, publication))
+}
+
+func TestFTARelationship(t *testing.T) {
+	assert := assert.New(t)
+
+	defer cleanDB(t, content11UUID, FTAGenreUUID)
+
+	publication := []string{FTAPublicationUUUID}
+	writeContent(assert, content11UUID)
+	writeAnnotations(assert, driver, content11UUID, "manual", "./fixtures/Annotations-22e528d3-4ceb-452f-bf88-0ff6b99eab22-manual.json", []interface{}{FTAPublicationUUUID})
+	writeConcept(assert, driver, "./fixtures/FTAGenre-11a8748c-24f9-4034-809b-eb5fcabf9611.json")
+
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
+
+	contentList, err := contentByConceptDriver.GetContentForConcept(FTAGenreUUID, RequestParams{0, defaultLimit, 0, 0, publication})
+	assert.NoError(err, "Unexpected error for concept %s", FTAGenreUUID)
+	assert.Equal(1, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
+	assertListContainsAll(assert, contentList, getExpectedContent(content11UUID, publication))
 }
 
 // These tests are aiming the service from the outside to validate opa policy authorization based on access-from and x-policy headers

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 )
 
 require (
-	github.com/Financial-Times/cm-annotations-ontology v1.0.4 // indirect
-	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.5 // indirect
+	github.com/Financial-Times/cm-annotations-ontology v1.0.6 // indirect
+	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12 // indirect
 	github.com/Financial-Times/http-handlers-go v0.0.0-20170809121007-229ac16f1d9e // indirect
 	github.com/Financial-Times/up-rw-app-api-go v0.0.0-20170710125828-d9d93a1f6895 // indirect
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/Financial-Times/api-endpoint v1.0.0 h1:EhJfcVcrktPrweue6dCUQAYcEQiXwh
 github.com/Financial-Times/api-endpoint v1.0.0/go.mod h1:QrJsxP8uEZIPJZon+qhc+zO7H0634DpoqDI291i0Nag=
 github.com/Financial-Times/base-ft-rw-app-go/v2 v2.0.0-20211207113529-d0faaa432d5d h1:/cnV7K/3NEwa0zXJJYgmlViCrrGqO0DCLUQG275bc+k=
 github.com/Financial-Times/base-ft-rw-app-go/v2 v2.0.0-20211207113529-d0faaa432d5d/go.mod h1:Td0/3sUrq7H7yHf86jcpVQ0LUvt5NWRUrRVjxgYIkAk=
-github.com/Financial-Times/cm-annotations-ontology v1.0.4 h1:e2j9SvvfnvgKQvIEbEKWrwbw0idYLq9iqTyr+XBWCL4=
-github.com/Financial-Times/cm-annotations-ontology v1.0.4/go.mod h1:/XnpxdtpDn+CgbTCecv81k6ebSgt+jNx5KrrO2zsP+8=
-github.com/Financial-Times/cm-graph-ontology/v2 v2.0.5 h1:KfUnzb4W4nqol1HjSZ95Qc9jUg6l+JmANaypXJkJBqQ=
-github.com/Financial-Times/cm-graph-ontology/v2 v2.0.5/go.mod h1:6Y6A7CSTLrH5An3FIP3j3c0ZQrsCDcOI/8SkkJEsOLg=
+github.com/Financial-Times/cm-annotations-ontology v1.0.6 h1:4Un7ft0/SULrPqNR6JeqoDrjPE3/Jxpev+yXufoGCls=
+github.com/Financial-Times/cm-annotations-ontology v1.0.6/go.mod h1:/9uneekJE5KFWipqreEWMh2JEnxAivnHomEslrsNY9g=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12 h1:ws5SkuTkDp8QYddh3ba26cg9vlAIsic+HfSK3Cr37mI=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12/go.mod h1:HNytPLbek0HwF5KX8m5cGNZ/HTdtXwTisR3HmCk7O/o=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1 h1:kmgRa3boe58+tzNTbWTBx3IQnIZt5Hh57Yc2kHy85FM=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1/go.mod h1:fQ77C8A+6I+ihwe6Ob8Y7sIzU3s/DTrjBZJGVQOeum0=
 github.com/Financial-Times/concepts-rw-neo4j v1.37.1 h1:9nYSbd3NvXwB/eSSzvNvK63A7zXgY6n2OpJRtQKzTfI=
@@ -169,7 +169,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=


### PR DESCRIPTION
# Description

Bump graph and annotations ontologies in order to allow reading of fta annotations

## What

Please be specific and try to describe your thought process. State the obvious, since this might be the first time the reviewer is looking at the code

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5351

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
