### PR TITLE
allow reading concepts with Generic authority and write test

### DIFF
--- a/content/fixtures/Annotations-3c4666ef-b403-4313-b648-d639762750e4.json
+++ b/content/fixtures/Annotations-3c4666ef-b403-4313-b648-d639762750e4.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "http://api.ft.com/things/3c4666ef-b403-4313-b648-d639762750e4",
+    "prefLabel": "Amy Winehouse",
+    "types": [
+      "Thing",
+      "Concept",
+      "Person"
+    ],
+    "predicate": "mentions"
+  }
+]

--- a/content/fixtures/Person-3c4666ef-b403-4313-b648-d639762750e4.json
+++ b/content/fixtures/Person-3c4666ef-b403-4313-b648-d639762750e4.json
@@ -1,0 +1,17 @@
+{
+  "aliases": [
+    "Amy Winehouse"
+  ],
+  "prefLabel": "Amy Winehouse",
+  "prefUUID": "3c4666ef-b403-4313-b648-d639762750e4",
+  "sourceRepresentations": [
+    {
+      "authority": "Generic",
+      "authorityValue": "3c4666ef-b403-4313-b648-d639762750e4",
+      "prefLabel": "Amy Winehouse",
+      "type": "Person",
+      "uuid": "3c4666ef-b403-4313-b648-d639762750e4"
+    }
+  ],
+  "type": "Person"
+}

--- a/content/service_test.go
+++ b/content/service_test.go
@@ -46,6 +46,7 @@ const (
 	JohnSmithSmartlogicUUID = "d46c09ce-7861-11e8-b45a-da24cd01f044"
 	JohnSmithTMEUUID        = "3af8b4e4-7862-11e8-b45a-da24cd01f044"
 	JohnSmithOtherTMEUUID   = "521a2338-2cc7-47dd-8da2-e757b4ceb7ef"
+	PersonUUID              = "3c4666ef-b403-4313-b648-d639762750e4"
 	topic1UUID              = "18e24d65-c8e6-4e23-ab19-206e0d463205"
 	topic2UUID              = "64ba2208-0c0d-43e2-a883-beecb55c0d33"
 	topic3UUID              = "2e7429bd-7a84-41cb-a619-2c702893e359"
@@ -449,6 +450,25 @@ func TestFTPCRelationship(t *testing.T) {
 
 	contentList, err := contentByConceptDriver.GetContentForConcept(FTPCSourceUUID, RequestParams{0, defaultLimit, 0, 0, publication})
 	assert.NoError(err, "Unexpected error for concept %s", FTPCSourceUUID)
+	assert.Equal(1, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
+	assertListContainsAll(assert, contentList, getExpectedContent(content12UUID, publication))
+}
+
+func TestGenericPerson(t *testing.T) {
+	assert := assert.New(t)
+
+	defer cleanDB(t, content12UUID, PersonUUID)
+
+	publication := []string{FTPCPublicationUUUID}
+	writeContent(assert, content12UUID)
+	writeAnnotations(assert, driver, content12UUID, "manual", "./fixtures/Annotations-3c4666ef-b403-4313-b648-d639762750e4.json", []interface{}{FTPCPublicationUUUID})
+	writeConcept(assert, driver, "./fixtures/Person-3c4666ef-b403-4313-b648-d639762750e4.json")
+
+	contentByConceptDriver, err := NewContentByConceptService(driver, apigURL)
+	assert.NoError(err)
+
+	contentList, err := contentByConceptDriver.GetContentForConcept(PersonUUID, RequestParams{0, defaultLimit, 0, 0, publication})
+	assert.NoError(err, "Unexpected error for concept %s", PersonUUID)
 	assert.Equal(1, len(contentList), "Didn't get the right number of content items, content=%s", contentList)
 	assertListContainsAll(assert, contentList, getExpectedContent(content12UUID, publication))
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 
 require (
 	github.com/Financial-Times/cm-annotations-ontology v1.0.7 // indirect
-	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12 // indirect
+	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14 // indirect
 	github.com/Financial-Times/http-handlers-go v0.0.0-20170809121007-229ac16f1d9e // indirect
 	github.com/Financial-Times/up-rw-app-api-go v0.0.0-20170710125828-d9d93a1f6895 // indirect
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Financial-Times/cm-annotations-ontology v1.0.7 h1:rKFItLoD7jWvW39wSrb
 github.com/Financial-Times/cm-annotations-ontology v1.0.7/go.mod h1:/9uneekJE5KFWipqreEWMh2JEnxAivnHomEslrsNY9g=
 github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12 h1:ws5SkuTkDp8QYddh3ba26cg9vlAIsic+HfSK3Cr37mI=
 github.com/Financial-Times/cm-graph-ontology/v2 v2.0.12/go.mod h1:HNytPLbek0HwF5KX8m5cGNZ/HTdtXwTisR3HmCk7O/o=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14 h1:W4OIzmHPSP++hoFuydrrx1/DYXL1N9uQwHFHg8vglfM=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14/go.mod h1:HNytPLbek0HwF5KX8m5cGNZ/HTdtXwTisR3HmCk7O/o=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1 h1:kmgRa3boe58+tzNTbWTBx3IQnIZt5Hh57Yc2kHy85FM=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1/go.mod h1:fQ77C8A+6I+ihwe6Ob8Y7sIzU3s/DTrjBZJGVQOeum0=
 github.com/Financial-Times/concepts-rw-neo4j v1.37.1 h1:9nYSbd3NvXwB/eSSzvNvK63A7zXgY6n2OpJRtQKzTfI=


### PR DESCRIPTION
# Description

## What

Update cm-graph-ontology library and allow reading generic concept authority.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5406)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
